### PR TITLE
Add operational limits to create command

### DIFF
--- a/src/valkey_search_options.cc
+++ b/src/valkey_search_options.cc
@@ -17,12 +17,21 @@ namespace options {
 constexpr uint32_t kHNSWDefaultBlockSize{10240};
 constexpr uint32_t kHNSWMinimumBlockSize{0};
 constexpr uint32_t kMaxThreadsCount{1024};
+constexpr uint32_t kMaxIndexesDefault{10};
+constexpr uint32_t kMaxPrefixesDefault{16};
+constexpr uint32_t kMaxTagFieldLenDefault{10000};
+constexpr uint32_t kMaxNumericFieldLenDefault{256};
 
 constexpr absl::string_view kHNSWBlockSizeConfig{"hnsw-block-size"};
 constexpr absl::string_view kReaderThreadsConfig{"reader-threads"};
 constexpr absl::string_view kWriterThreadsConfig{"writer-threads"};
 constexpr absl::string_view kUseCoordinator{"use-coordinator"};
 constexpr absl::string_view kLogLevel{"log-level"};
+constexpr absl::string_view kMaxIndexesConfig{"max-indexes"};
+constexpr absl::string_view kMaxPrefixesConfig{"max-prefixes"};
+constexpr absl::string_view kMaxTagFieldLenConfig{"max-tag-field-length"};
+constexpr absl::string_view kMaxNumericFieldLenConfig{
+    "max-numeric-field-length"};
 
 static const int64_t kDefaultThreadsCount = vmsdk::GetPhysicalCPUCoresCount();
 
@@ -139,6 +148,42 @@ static auto log_level =
         .WithValidationCallback(ValidateLogLevel)
         .Build();
 
+/// Register the "--max-indexes" flag. Controls the max number of indexes we can
+/// have.
+static auto max_indexes =
+    config::NumberBuilder(kMaxIndexesConfig,   // name
+                          kMaxIndexesDefault,  // default size
+                          1,                   // min size
+                          UINT_MAX)            // max size
+        .Build();
+
+/// Register the "--max-prefixes" flag. Controls the max number of prefixes per
+/// index.
+static auto max_prefixes =
+    config::NumberBuilder(kMaxPrefixesConfig,   // name
+                          kMaxPrefixesDefault,  // default size
+                          1,                    // min size
+                          UINT_MAX)             // max size
+        .Build();
+
+/// Register the "--max-tag-field-length" flag. Controls the max length of a tag
+/// field.
+static auto max_tag_field_len =
+    config::NumberBuilder(kMaxTagFieldLenConfig,   // name
+                          kMaxTagFieldLenDefault,  // default size
+                          1,                       // min size
+                          UINT_MAX)                // max size
+        .Build();
+
+/// Register the "--max-numeric-field-length" flag. Controls the max length of a
+/// numeric field.
+static auto max_numeric_field_len =
+    config::NumberBuilder(kMaxNumericFieldLenConfig,   // name
+                          kMaxNumericFieldLenDefault,  // default size
+                          1,                           // min size
+                          UINT_MAX)                    // max size
+        .Build();
+
 vmsdk::config::Number& GetHNSWBlockSize() {
   return dynamic_cast<vmsdk::config::Number&>(*hnsw_block_size);
 }
@@ -149,6 +194,22 @@ vmsdk::config::Number& GetReaderThreadCount() {
 
 vmsdk::config::Number& GetWriterThreadCount() {
   return dynamic_cast<vmsdk::config::Number&>(*writer_threads_count);
+}
+
+vmsdk::config::Number& GetMaxIndexes() {
+  return dynamic_cast<vmsdk::config::Number&>(*max_indexes);
+}
+
+vmsdk::config::Number& GetMaxPrefixes() {
+  return dynamic_cast<vmsdk::config::Number&>(*max_prefixes);
+}
+
+vmsdk::config::Number& GetMaxTagFieldLen() {
+  return dynamic_cast<vmsdk::config::Number&>(*max_tag_field_len);
+}
+
+vmsdk::config::Number& GetMaxNumericFieldLen() {
+  return dynamic_cast<vmsdk::config::Number&>(*max_numeric_field_len);
 }
 
 const vmsdk::config::Boolean& GetUseCoordinator() {

--- a/src/valkey_search_options.h
+++ b/src/valkey_search_options.h
@@ -24,6 +24,18 @@ config::Number& GetReaderThreadCount();
 /// number of writer threads
 config::Number& GetWriterThreadCount();
 
+/// Return the maximum number of indexes allowed to create.
+config::Number& GetMaxIndexes();
+
+/// Return the maximum number of prefixes allowed per index.
+config::Number& GetMaxPrefixes();
+
+/// Return the maximum length of a tag field.
+config::Number& GetMaxTagFieldLen();
+
+/// Return the maximum length of a numeric field.
+config::Number& GetMaxNumericFieldLen();
+
 /// Return an immutable reference to the "use-coordinator" flag
 const config::Boolean& GetUseCoordinator();
 

--- a/testing/CMakeLists.txt
+++ b/testing/CMakeLists.txt
@@ -29,6 +29,8 @@ set(SRCS_FT_CREATE_PARSER_TEST
 add_executable(ft_create_parser_test ${SRCS_FT_CREATE_PARSER_TEST})
 target_include_directories(ft_create_parser_test
                            PUBLIC ${CMAKE_CURRENT_LIST_DIR})
+target_link_libraries(ft_create_parser_test PUBLIC valkey_search)
+target_link_libraries(ft_create_parser_test PUBLIC server_events)
 target_link_libraries(ft_create_parser_test PUBLIC index_schema_cc_proto)
 target_link_libraries(ft_create_parser_test PUBLIC ft_create_parser)
 target_link_libraries(ft_create_parser_test PUBLIC index_base)


### PR DESCRIPTION
# Add operational limits to create command

This PR adds configurable operational limits to the FT.CREATE command to prevent resource exhaustion.

## Changes

- Added four configurable operational limits:
  - `max-indexes`: Maximum number of indexes allowed to create (default: 10)
  - `max-prefixes`: Maximum number of prefixes allowed per index (default: 16)
  - `max-tag-field-length`: Maximum length of a tag field (default: 10000)
  - `max-numeric-field-length`: Maximum length of a numeric field (default: 256)

- Implemented validation in the following components:
  - `SchemaManager::CreateIndexSchema`: Enforces the maximum number of indexes
  - `ParsePrefixes`: Enforces the maximum number of prefixes per index
  - `ParseTag`: Enforces the maximum length of tag fields
  - `ParseNumeric`: Enforces the maximum length of numeric fields

- Added test coverage for all limits in `ft_create_test.cc`

## Motivation

These operational limits help prevent resource exhaustion by limiting the scale of index creation operations. The default values provide reasonable limits for most use cases while still allowing configuration for specific needs.

Implements: Enforce limit on the maximum number of indexes and fields. #121 
